### PR TITLE
fix(ErrorHandling): Added killswitch for shutting service down on too many failed transactions or gas lost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,7 @@ PERCENT_SLIPPAGE=
 
 # Number of times to retry trying to calculate gas on a given order before giving up on it.  Usually only an issue for orders that involve "bad" ERC20 tokens.
 BAD_ORDER_RETRY=
+
+# Percentage of gas limit slippage (as expressed by percentage of estimated gas) to use when calculating whether or not to attempt an execution.  Up to two significant digits allowed.
+# E.g. 0.05 means 0.05%
+GAS_LIMIT_SLIPPAGE=

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,17 @@ PERCENT_SLIPPAGE=
 # Number of times to retry trying to calculate gas on a given order before giving up on it.  Usually only an issue for orders that involve "bad" ERC20 tokens.
 BAD_ORDER_RETRY=
 
-# Percentage of gas limit slippage (as expressed by percentage of estimated gas) to use when calculating whether or not to attempt an execution.  Up to two significant digits allowed.
-# E.g. 0.05 means 0.05%
-GAS_LIMIT_SLIPPAGE=
+# Number of failed execution attempts before shutting down service
+MAX_FAILURE_COUNT=
+
+# Amount of gas to spend on failed execution attempts before shutting down service
+MAX_FAILURE_GAS_COST=
+
+# Amount of time (in milliseconds) to wait after first failure before resetting failure count
+MAX_FAILURE_DURATION=
+
+# Whether to reset failure duration timer on each new failure.  Valid values are: true, false
+RESET_TIMER_ON_FAILURE=
+
+# Where to send a notification that the service has shutdown from failure conditions
+FAILURE_SHUTDOWN_WEBHOOK_URL=

--- a/nodemon.json
+++ b/nodemon.json
@@ -2,7 +2,7 @@
   "watch": ["src"],
   "ext": "ts",
   "ignore": ["src/**/*.test.ts"],
-  "exec": "yarn main",
+  "exec": "yarn start",
   "env": {
     "DEBUG": "unitrade-service*"
   }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,8 +19,14 @@ export interface IConfig {
   percentSlippage: string;
   gasPriceLevel: string;
   badOrderRetry: string;
-  gasLimitSlippage: string;
+  maxFailureCount: string;
+  maxFailureGasCost: string;
+  maxFailureDuration: string;
+  resetTimerOnFailure: string;
+  failureShutdownWebhookUrl: string;
 }
+
+const getOptionalEnv = (key: string) => process.env[key];
 
 const getEnv = (key: string) => {
   const value = process.env[key];
@@ -48,5 +54,9 @@ export const config: IConfig = {
   percentSlippage: getEnv("PERCENT_SLIPPAGE"),
   gasPriceLevel: getEnv("GAS_PRICE_LEVEL"),
   badOrderRetry: getEnv("BAD_ORDER_RETRY"),
-  gasLimitSlippage: getEnv("GAS_LIMIT_SLIPPAGE"),
+  maxFailureCount: getEnv("MAX_FAILURE_COUNT"),
+  maxFailureGasCost: getEnv("MAX_FAILURE_GAS_COST"),
+  maxFailureDuration: getEnv("MAX_FAILURE_DURATION"),
+  resetTimerOnFailure: getOptionalEnv("RESET_TIMER_ON_FAILURE") || "false",
+  failureShutdownWebhookUrl: getOptionalEnv("FAILURE_SHUTDOWN_WEBHOOK_URL") || "",
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,6 +19,7 @@ export interface IConfig {
   percentSlippage: string;
   gasPriceLevel: string;
   badOrderRetry: string;
+  gasLimitSlippage: string;
 }
 
 const getEnv = (key: string) => {
@@ -47,4 +48,5 @@ export const config: IConfig = {
   percentSlippage: getEnv("PERCENT_SLIPPAGE"),
   gasPriceLevel: getEnv("GAS_PRICE_LEVEL"),
   badOrderRetry: getEnv("BAD_ORDER_RETRY"),
+  gasLimitSlippage: getEnv("GAS_LIMIT_SLIPPAGE"),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,23 +12,38 @@ import Web3 from "web3";
 import { config } from "./config";
 import { loader } from "./utils/loader";
 import { TokenPool } from "./lib/classes";
-import { IDependencies, IUniTradeOrder, OrderState } from "./lib/types";
+import { IContractEvent, ExitCodes, IDependencies, IUniTradeOrder, OrderState } from "./lib/types";
 import { toBN } from "web3-utils";
 const log = debug("unitrade-service");
 
 export class UniTradeExecutorService {
   private dependencies: IDependencies;
   private activeOrders: IUniTradeOrder[];
+  private orderLocks: { [key: string]: boolean } = {};
   private badOrderMap: { [key: string]: number } = {};
   private pools: { [pairAddress: string]: TokenPool } = {};
   private poolListeners: { [pairAddress: string]: EventEmitter } = {};
   private orderListeners: { [eventName: string]: EventEmitter } = {};
+  private failureListener: EventEmitter;
+  private failedTxnTimer: any = null;
+  private failedTxnCount: number = 0;
+  private failedTxnGasCost: number = 0;
+
+  /**
+   * Log an error and/or shutdown the service
+   */
+  private handleError(error: Error, exitCode = ExitCodes.GenericError) {
+    log(error);
+    if (exitCode) {
+      this.handleShutdown(exitCode);
+    }
+  }
 
   /**
    * Gracefully handle app shutdown
    * @param exitCode
    */
-  private handleShutdown(exitCode = 0) {
+  private async handleShutdown(exitCode = ExitCodes.Success) {
     try {
       log("Shutting down...");
 
@@ -50,6 +65,22 @@ export class UniTradeExecutorService {
         }
       }
 
+      if (this.failureListener) this.failureListener.removeAllListeners();
+
+      if (exitCode > ExitCodes.GenericError && config.failureShutdownWebhookUrl) {
+        log("Sending shutdown notification to URL: %s", config.failureShutdownWebhookUrl);
+
+        await fetch(config.failureShutdownWebhookUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            text: `Executor service has shut down with exit code ${exitCode}`,
+          }),
+        });
+      }
+
       process.exit(exitCode);
     } catch (err) {
       log("Error during shutdown: %O", err);
@@ -58,7 +89,12 @@ export class UniTradeExecutorService {
   }
 
   constructor() {
-    this.start();
+    try {
+      this.start();
+    } catch (err) {
+      log("Error: %O", err);
+      this.handleShutdown(ExitCodes.GenericError);
+    }
     process.on("SIGINT", () => {
       this.handleShutdown();
     });
@@ -66,6 +102,20 @@ export class UniTradeExecutorService {
       this.handleShutdown();
     });
   }
+
+  /**
+   * Lock an order so it's not run twice
+   * @param orderId
+   */
+  private lockOrder = (orderId: number) => (this.orderLocks[orderId] = true);
+
+  /**
+   * Unlock an order for executing
+   * @param orderId
+   */
+  private unlockOrder = (orderId: number) => {
+    if (this.orderLocks[orderId]) delete this.orderLocks[orderId];
+  };
 
   /**
    * Get or Create TokenPool
@@ -90,7 +140,7 @@ export class UniTradeExecutorService {
       const pool = this.getOrCreatePool(pairAddress);
       pool.addOrder(orderId, order);
     } catch (err) {
-      log("%O", err);
+      this.handleError(err, ExitCodes.GenericError);
     }
   };
 
@@ -109,26 +159,34 @@ export class UniTradeExecutorService {
         orderPool.removeOrder(orderId);
       }
     } catch (err) {
-      log("%O", err);
+      this.handleError(err, ExitCodes.GenericError);
     }
   };
 
   private executeIfAppropriate = async (order: IUniTradeOrder) => {
+    if (this.orderLocks[order.orderId]) return false;
+
     log(`Checking if order ${order.orderId} is executable...`);
 
     // Avoid to try to execute an Executed/Cancelled order
-    const isActive = order.orderState.toString() === OrderState.Placed.toString();
+    const isActive = order.orderState == OrderState.Placed;
     if (!isActive) {
       log(`Order ${order.orderId} isn't active (current state is ${order.orderState}), ignoring it.`);
       return false;
     }
 
+    // lock the order so it doesn't get processed multiple times
+    this.lockOrder(order.orderId);
+
     const inTheMoney = await this.dependencies.providers.uniSwap?.isInTheMoney(order);
     if (inTheMoney) {
       let estimatedGas;
       try {
-        estimatedGas = await this.dependencies.providers.ethGasStation?.getEstimatedGasForOrder(order.orderId);
-        log('Got estimated gas for order %s: %s', order.orderId, estimatedGas);
+        // override the estimated gas for debugging purposes
+        estimatedGas = process.env.ESTIMATED_GAS_OVERRIDE
+          ? parseInt(process.env.ESTIMATED_GAS_OVERRIDE, 10)
+          : await this.dependencies.providers.ethGasStation?.getEstimatedGasForOrder(order.orderId);
+        log("Got estimated gas for order %s: %s", order.orderId, estimatedGas);
       } catch (err) {
         log(`Failed order: ${JSON.stringify(order)}`);
         if (this.badOrderMap[order.orderId]) {
@@ -143,21 +201,26 @@ export class UniTradeExecutorService {
       }
       if (!estimatedGas) {
         log("Cannot retrieve preferred estimated gas for order %s", order.orderId);
+        this.unlockOrder(order.orderId);
         return false;
       }
       const gasPrice = this.dependencies.providers.ethGasStation?.getPreferredGasPrice();
       if (!gasPrice) {
         log("Cannot retrieve preferred gas price for order %s", order.orderId);
+        this.unlockOrder(order.orderId);
         return false;
       }
 
-      const gasSlippage = config.gasLimitSlippage ? parseFloat(config.gasLimitSlippage) : 1;
-      log("Configured gas slippage value: %s", gasSlippage);
-
-      const gas = toBN(estimatedGas * gasSlippage).mul(toBN(gasPrice));
+      const gas = toBN(estimatedGas).mul(toBN(gasPrice));
 
       if (gas.lt(toBN(order.executorFee))) {
-        return await this.dependencies.providers.uniTrade?.executeOrder(order, estimatedGas * gasSlippage, gasPrice);
+        try {
+          return await this.dependencies.providers.uniTrade?.executeOrder(order, estimatedGas, gasPrice);
+        } catch (err) {
+          this.handleFailedExecution(err.receipt);
+          this.unlockOrder(order.orderId);
+          return false;
+        }
       } else {
         log(
           "Executor fee for order %s is not high enough to cover the estimated gas cost of executing order (%s < %s)",
@@ -168,7 +231,55 @@ export class UniTradeExecutorService {
       }
     }
     log(`Order ${order.orderId} isn't "In the money" ignoring it...`);
+    this.unlockOrder(order.orderId);
     return false;
+  };
+
+  /**
+   * Handle failures and shut down if necessary
+   * @param receipt
+   * @returns
+   */
+  private handleFailedExecution = (receipt: any) => {
+    if (!receipt) return;
+
+    this.failedTxnCount += 1;
+    this.failedTxnGasCost += receipt.gasUsed || 0;
+
+    log(
+      "Transaction %s failed!\n\nFailed txns: %s/%s\nFailed txn gas cost: %s/%s\n\n",
+      receipt.transactionHash,
+      this.failedTxnCount,
+      config.maxFailureCount,
+      this.failedTxnGasCost,
+      config.maxFailureGasCost
+    );
+
+    if (config.maxFailureCount && this.failedTxnCount >= parseInt(config.maxFailureCount)) {
+      this.handleError(
+        new Error("Number of failed transactions is over the limit - service is shutting down"),
+        ExitCodes.TooManyFailures
+      );
+    }
+    if (config.maxFailureGasCost && this.failedTxnGasCost >= parseInt(config.maxFailureGasCost)) {
+      this.handleError(
+        new Error("Gas cost of failed transactions is over the limit - service is shutting down"),
+        ExitCodes.TooMuchGasLost
+      );
+    }
+
+    // set the timer
+    if (config.maxFailureDuration) {
+      if (!this.failedTxnTimer || config.resetTimerOnFailure?.toLowerCase() === "true") {
+        log("Setting failed transaction timer with duration %s ms", config.maxFailureDuration);
+        this.failedTxnTimer = setTimeout(() => {
+          log("Failed transactions timer expired - resetting failed transaction count");
+          this.failedTxnCount = 0;
+          this.failedTxnGasCost = 0;
+          this.failedTxnTimer = null;
+        }, parseInt(config.maxFailureDuration));
+      }
+    }
   };
 
   /**
@@ -208,14 +319,14 @@ export class UniTradeExecutorService {
         log("Listener connected to UniSwap Sync events for pairAddress %s", pairAddress);
       });
       this.poolListeners[pairAddress].on("error", (err) => {
-        log(err);
+        this.handleError(err, ExitCodes.GenericError);
       });
       this.poolListeners[pairAddress].on("end", async () => {
         log("Listener lost connection to UniSwap Sync events for pairAddress %s! Reconnecting...", pairAddress);
         this.createPoolChangeListener(pairAddress);
       });
     } catch (err) {
-      log("%O", err);
+      this.handleError(err, ExitCodes.GenericError);
     }
   };
 
@@ -247,14 +358,14 @@ export class UniTradeExecutorService {
         log("Listener connected to UniTrade OrderPlaced events");
       });
       this.orderListeners.OrderPlaced.on("error", (err) => {
-        log(err);
+        this.handleError(err, ExitCodes.GenericError);
       });
       this.orderListeners.OrderPlaced.on("end", async () => {
         log("Listener disconnected from UniTrade OrderPlaced events!");
         this.createOrderPlacedListener();
       });
     } catch (err) {
-      throw err;
+      this.handleError(err, ExitCodes.GenericError);
     }
   };
 
@@ -272,7 +383,7 @@ export class UniTradeExecutorService {
 
       this.orderListeners.OrderCancelled = await uniTradeEvents.OrderCancelled((err: Error) => {
         if (err) {
-          log(err);
+          this.handleError(err, ExitCodes.GenericError);
           return;
         }
       });
@@ -299,14 +410,14 @@ export class UniTradeExecutorService {
         log("Listener connected to UniTrade OrderCancelled events");
       });
       this.orderListeners.OrderCancelled.on("error", (err) => {
-        log(err);
+        this.handleError(err, ExitCodes.GenericError);
       });
       this.orderListeners.OrderCancelled.on("end", async () => {
         log("Listener disconnected from UniTrade OrderCancelled events!");
         this.createOrderCancelledListener();
       });
     } catch (err) {
-      throw err;
+      this.handleError(err, ExitCodes.GenericError);
     }
   };
 
@@ -324,12 +435,31 @@ export class UniTradeExecutorService {
 
       this.orderListeners.OrderExecuted = await uniTradeEvents.OrderExecuted((err: Error) => {
         if (err) {
-          log(err);
+          this.handleError(err, ExitCodes.GenericError);
           return;
         }
       });
-      this.orderListeners.OrderExecuted.on("data", async (event: any) => {
-        if (event.returnValues) {
+      this.orderListeners.OrderExecuted.on("data", async (event: IContractEvent) => {
+        // did the execution attempt fail?
+        const receipt = await this.dependencies.providers.uniTrade?.web3.eth.getTransactionReceipt(
+          event.transactionHash
+        );
+
+        log("Got receipt for event %O: %O", event, receipt);
+
+        // if (receipt === null) {
+        //   this.pendingExecutions.push(event.transactionHash);
+        //   if (!this.pendingExecutionChecker) {
+        //     this.checkPendingExecutions();
+        //     this.pendingExecutionChecker = setInterval(() => {
+        //       this.checkPendingExecutions();
+        //     }, this.pendingExecutionInterval);
+        //   }
+        // }
+
+        if (receipt && !receipt.status) {
+          this.handleFailedExecution(event.transactionHash);
+        } else if (event.returnValues) {
           log("Received UniTrade OrderExecuted event for orderId: %s", event.returnValues.orderId);
           const order = event.returnValues as IUniTradeOrder;
           this.removePoolOrder(order.orderId, order);
@@ -350,14 +480,14 @@ export class UniTradeExecutorService {
         log("Listener connected to UniTrade OrderExecuted events");
       });
       this.orderListeners.OrderExecuted.on("error", (err) => {
-        log(err);
+        this.handleError(err, ExitCodes.GenericError);
       });
       this.orderListeners.OrderExecuted.on("end", async () => {
         log("Listener disconnected from UniTrade OrderExecuted events!");
         this.createOrderExecutedListener();
       });
     } catch (err) {
-      throw err;
+      this.handleError(err, ExitCodes.GenericError);
     }
   };
 
@@ -371,6 +501,12 @@ export class UniTradeExecutorService {
       const web3 = new Web3(config.provider.uri);
 
       this.dependencies = loader(web3);
+
+      if (!this.dependencies.providers.uniSwap) throw new Error("UniSwap Provider not loaded! Shutting down...");
+      else if (!this.dependencies.providers.uniTrade) throw new Error("UniTrade Provider not loaded! Shutting down...");
+      else if (!this.dependencies.providers.account) throw new Error("Account Provider not loaded! Shutting down...");
+      else if (!this.dependencies.providers.ethGasStation)
+        throw new Error("EthGasStation Provider not loaded! Shutting down...");
 
       this.activeOrders = (await this.dependencies.providers.uniTrade?.listOrders()) || [];
 
@@ -389,10 +525,11 @@ export class UniTradeExecutorService {
       await this.createOrderPlacedListener();
       await this.createOrderCancelledListener();
       await this.createOrderExecutedListener();
+      // await this.createFailedTxnListener();
 
       log("UniTrade executor service is now running!");
     } catch (err) {
-      log("%O", err);
+      this.handleError(err, ExitCodes.GenericError);
     }
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,12 @@
 import { UniTradeProvider, UniSwapProvider, AccountProvider, EthGasStationProvider } from "../providers";
 
+export enum ExitCodes {
+  Success = 0,
+  GenericError = 1,
+  TooManyFailures = 2,
+  TooMuchGasLost = 3,
+}
+
 /**
  * Dependencies
  */
@@ -9,6 +16,25 @@ export class IDependencies {
     uniTrade?: UniTradeProvider;
     uniSwap?: UniSwapProvider;
     ethGasStation?: EthGasStationProvider;
+  };
+}
+
+/**
+ * Contract Events
+ */
+export interface IContractEvent {
+  event: string;
+  signature: string | null;
+  address: string;
+  returnValues?: { [key: string]: any };
+  logIndex: number;
+  transactionIndex: number;
+  transactionHash: string;
+  blockHash: string;
+  blockNumber: number;
+  raw: {
+    data: string;
+    topics: string[];
   };
 }
 

--- a/src/providers/unitrade-provider.ts
+++ b/src/providers/unitrade-provider.ts
@@ -76,8 +76,7 @@ export class UniTradeProvider extends Dependency {
         });
       return true;
     } catch (err) {
-      log("Error executing order %s: %O", order.orderId, err);
-      return false;
+      throw err;
     }
   };
 }


### PR DESCRIPTION
- Added five new env vars:

```
# Number of failed execution attempts before shutting down service
MAX_FAILURE_COUNT=

# Amount of gas to spend on failed execution attempts before shutting down service
MAX_FAILURE_GAS_COST=

# Amount of time (in milliseconds) to wait after first failure before resetting failure count
MAX_FAILURE_DURATION=

# Whether to reset failure duration timer on each new failure.  Valid values are: true, false
RESET_TIMER_ON_FAILURE=

# Where to send a notification that the service has shutdown from failure conditions
FAILURE_SHUTDOWN_WEBHOOK_URL=
```

- Added logic to POST a notification to a given Slack webhook URL on shutdown

- Added logic to "lock" orders while waiting for execution response (so they don't get run twice)

- Added more descriptive error codes and improved error handling in general